### PR TITLE
Add dark and light mode toggle

### DIFF
--- a/src/components/ui-system/components/layout/layout.tsx
+++ b/src/components/ui-system/components/layout/layout.tsx
@@ -9,6 +9,8 @@ import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import { useSystemService } from "@/hooks/useSystemService";
 import { openModal } from "@/store/slices/modal-slice";
 import { useAppDispatch } from "@/hooks/hooks";
+import ThemeToggle from "@/components/ui/theme-toggle";
+import { cn } from "@/lib/utils";
 
 type Props = {
   children?: React.ReactNode;
@@ -25,26 +27,28 @@ const Layout = ({ children }: Props) => {
   }, [loading]);
 
   useEffect(() => {
-    if (error) {
-      dispatch(
-        openModal({
-          title: "",
-          template: "ERROR",
-          content: "",
-        })
-      );
+    if (!error) {
       return;
     }
-  }, [loading]);
+
+    dispatch(
+      openModal({
+        title: "",
+        template: "ERROR",
+        content: "",
+      })
+    );
+  }, [dispatch, error]);
 
   return (
     <>
-      <div className="flex">
+      <div className="flex bg-background text-foreground">
         {!isHideSidebar && <Sidebar />}
         <div
-          className={`"flex flex-col min-h-screen flex-grow transition-all duration-1000 ${
-            !isHideSidebar ? "ml-[60px] " : "ml-0"
-          }"`}
+          className={cn(
+            "flex flex-col min-h-screen flex-grow transition-all duration-300",
+            !isHideSidebar ? "ml-[60px]" : "ml-0"
+          )}
         >
           {/* <section className="w-full p-3 bg-blue-500 text-white text-center">
             Develop version
@@ -58,10 +62,13 @@ const Layout = ({ children }: Props) => {
           ) : (
             ""
           )}
-          <main className="flex-1 flex flex-col p-4 my-container">
+          <main className="flex-1 flex flex-col gap-6 p-4 my-container">
+            <div className="flex justify-end">
+              <ThemeToggle />
+            </div>
             {children}
           </main>
-          <footer className="bg-[#F1F1F1] p-4"></footer>
+          <footer className="bg-secondary text-secondary-foreground p-4 transition-colors"></footer>
         </div>
       </div>
 

--- a/src/components/ui-system/components/layout/sidebar.tsx
+++ b/src/components/ui-system/components/layout/sidebar.tsx
@@ -29,10 +29,10 @@ const Sidebar = () => {
   const location = useLocation();
 
   const itemClass =
-    "p-3 flex flex-col justify-center items-center text-xs gap-1";
-  const activeClass = "bg-gray-300 ";
+    "p-3 flex flex-col justify-center items-center text-xs gap-1 text-foreground transition-colors hover:bg-muted";
+  const activeClass = "bg-muted font-semibold";
   return (
-    <div className="bg-[#EBEBEB] h-screen w-[60px] fixed border-r border-gray-200 pb-12">
+    <div className="bg-secondary text-secondary-foreground h-screen w-[60px] fixed border-r border-border pb-12 transition-colors">
       <div className="h-full flex justify-between flex-col">
         <div className="flex flex-col">
           {listMenu.map((i, key) => (

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { Moon, Sun } from "lucide-react";
+
+import { Button } from "./button";
+import { useAppDispatch, useAppSelector } from "@/hooks/hooks";
+import { toggleTheme } from "@/store/slices/theme-slice";
+import { cn } from "@/lib/utils";
+
+const ThemeToggle = () => {
+  const dispatch = useAppDispatch();
+  const theme = useAppSelector((state) => state.theme.theme);
+
+  useEffect(() => {
+    if (typeof document === "undefined" || typeof window === "undefined") {
+      return;
+    }
+
+    const root = document.documentElement;
+
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+
+    root.dataset.theme = theme;
+    window.localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const onToggleTheme = () => {
+    dispatch(toggleTheme());
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={onToggleTheme}
+      aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+      className="relative"
+    >
+      <Sun
+        className={cn(
+          "absolute h-5 w-5 transition-all duration-300",
+          theme === "dark" ? "rotate-90 scale-0" : "rotate-0 scale-100"
+        )}
+      />
+      <Moon
+        className={cn(
+          "absolute h-5 w-5 transition-all duration-300",
+          theme === "dark" ? "rotate-0 scale-100" : "-rotate-90 scale-0"
+        )}
+      />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,10 @@
 @import "tw-animate-css";
 
 body {
-  background-color: #f6f6f6;
+  background-color: var(--background);
   font-family: "Inter", sans-serif;
-  color: #1d1d1f;
+  color: var(--foreground);
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .my-container {

--- a/src/store/slices/theme-slice.ts
+++ b/src/store/slices/theme-slice.ts
@@ -1,0 +1,42 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+export type ThemeMode = "light" | "dark";
+
+const getInitialTheme = (): ThemeMode => {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const storedTheme = window.localStorage.getItem("theme");
+  if (storedTheme === "light" || storedTheme === "dark") {
+    return storedTheme;
+  }
+
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  return prefersDark ? "dark" : "light";
+};
+
+type ThemeState = {
+  theme: ThemeMode;
+};
+
+const initialState: ThemeState = {
+  theme: getInitialTheme(),
+};
+
+const themeSlice = createSlice({
+  name: "theme",
+  initialState,
+  reducers: {
+    toggleTheme: (state) => {
+      state.theme = state.theme === "dark" ? "light" : "dark";
+    },
+    setTheme: (state, action: PayloadAction<ThemeMode>) => {
+      state.theme = action.payload;
+    },
+  },
+});
+
+export const { toggleTheme, setTheme } = themeSlice.actions;
+
+export default themeSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3,6 +3,7 @@ import modalReducer from "./slices/modal-slice";
 import loadingReducer from "./slices/loading-slice";
 import soundReducer from "./slices/notice-slice";
 import orderReducer from "./slices/order-slice";
+import themeReducer from "./slices/theme-slice";
 
 export const store = configureStore({
   reducer: {
@@ -10,6 +11,7 @@ export const store = configureStore({
     loading: loadingReducer,
     sound: soundReducer,
     orders: orderReducer,
+    theme: themeReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- add a reusable theme toggle component that persists preference in local storage
- register a Redux slice for theme state and apply the selected mode across the layout
- refresh layout, sidebar, and base styles so the interface adapts to dark and light themes

## Testing
- npm run lint *(fails: existing lint rule configuration errors and unrelated lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e4fd7e62908322a9633cb83ea560c0